### PR TITLE
Shard docs + small infra/docs improvements

### DIFF
--- a/docs/backlog/epic-1-teams-rosters.md
+++ b/docs/backlog/epic-1-teams-rosters.md
@@ -1,0 +1,24 @@
+# Epic 1: Teams & Rosters
+
+User Stories:
+
+- Coach can create a team and invite players/guardians.
+- Admin can import/export roster CSV.
+- Parent can update child profile.
+
+Acceptance:
+
+- Org-scoped access; roles enforced (coach, player, guardian, admin).
+- CSV import validates required fields and handles duplicates with a master
+  record strategy.
+
+Tasks:
+
+- Prisma: Team, Membership, Guardianship, RosterMembership.
+- Routes/UI: `/teams`, `/teams/:teamId`, `/teams/:teamId/roster`.
+- CSV import/export utilities + tests.
+- RBAC policies + unit tests.
+- E2E: create team, add players, guardian invite flow (stubbed).
+- Guardian invite email via Resend (SMTP fallback) + test stub.
+- Parent profile update route/forms + optimistic UI + tests.
+- CSV duplicate handling with master record strategy + unit tests.

--- a/docs/backlog/epic-2-scheduling.md
+++ b/docs/backlog/epic-2-scheduling.md
@@ -1,0 +1,20 @@
+# Epic 2: Scheduling
+
+Stories:
+
+- Coach creates practices/games; parents see calendar.
+- Parent with multiple teams sees combined calendar.
+
+Acceptance:
+
+- Notifications on event create/update/cancel.
+- Timezone aware; conflict hint within same team.
+
+Tasks:
+
+- Prisma: Event, Resource (optional), indices.
+- Routes/UI: calendar list/month; ICS export.
+- Validation + tests; E2E for create/edit/delete.
+- Notification hooks (email/push) for create/update/cancel.
+- Timezone normalization/display tests; server/client consistency.
+- Performance test: calendar queries ≤1s for ≤50 players.

--- a/docs/backlog/epic-3-availability.md
+++ b/docs/backlog/epic-3-availability.md
@@ -1,0 +1,19 @@
+# Epic 3: Availability
+
+Stories:
+
+- Player marks Yes/No/Maybe; coach sees summary.
+
+Acceptance:
+
+- RSVP status visible to coach; filterable by status.
+- Reminders sent for unmarked within 24h of event.
+
+Tasks:
+
+- Prisma: Availability.
+- Routes/UI: `/events/:eventId/availability`.
+- Worker job: reminder email stub; retries.
+- Coach availability summary view (per event/team) + tests.
+- RSVP filters (Yes/No/Maybe) in UI and API.
+- Admin export across teams (CSV) + access checks.

--- a/docs/backlog/epic-4-messaging-announcements.md
+++ b/docs/backlog/epic-4-messaging-announcements.md
@@ -1,0 +1,16 @@
+# Epic 4: Messaging & Announcements
+
+Stories:
+
+- Coach posts announcement; parent sends direct message; basic team chat.
+  Acceptance:
+- Thread list, message history, unread states; audit log entries; retention
+  policy defined.
+
+Tasks:
+
+- Prisma: MessageThread, Message, AuditLog.
+- Routes/UI: `/threads`, `/threads/:id/messages`.
+- RBAC + retention policy.
+- Unread state tracking per thread/user + tests.
+- Retention cleanup job + tests.

--- a/docs/backlog/epic-5-notifications-preferences.md
+++ b/docs/backlog/epic-5-notifications-preferences.md
@@ -1,0 +1,9 @@
+# Epic 5: Notifications & Preferences
+
+Tasks:
+
+- Resend adapter + SMTP fallback; PWA push subscription.
+- NotificationPreference model; user settings page.
+- DLQ/retry mechanism; admin error log route.
+- Preferences UI (opt‑in/out per channel) + persistence tests.
+- Exponential backoff ≥3 retries; SMTP fallback path tests.

--- a/docs/backlog/epic-6-multi-team-support.md
+++ b/docs/backlog/epic-6-multi-team-support.md
@@ -1,0 +1,20 @@
+# Epic 6: Multi-Team Support
+
+Stories:
+
+- Parent/coach can switch between teams from header/menu.
+- Parent with multiple teams sees a unified calendar view.
+
+Acceptance:
+
+- RBAC scope preserved when switching teams.
+- Unified calendar render ≤2s for ≤5 teams and ≤100 events.
+- Persistent selection (session‑based) and accessible navigation.
+
+Tasks:
+
+- UI: Team switcher component; global context for active team(s).
+- Calendar: filter + merge multiple teams; perf test.
+- Tests: E2E team switch and combined calendar.
+- Persist selection in session; restore on login.
+- Accessibility: labels and keyboard navigation for switcher.

--- a/docs/backlog/epic-7-self-hosting-docs-setup-wizard.md
+++ b/docs/backlog/epic-7-self-hosting-docs-setup-wizard.md
@@ -1,0 +1,8 @@
+# Epic 7: Self-Hosting Docs & Setup Wizard
+
+Tasks:
+
+- Docker Compose works out‑of‑box with `.env.example`; health endpoints exposed
+  (`/healthz`, `/readyz`).
+- Setup wizard creates org + admin user; validates email provider configuration.
+- Self-hosting guide validated by non-developer; feedback loop captured.

--- a/docs/backlog/epics-priority-order.md
+++ b/docs/backlog/epics-priority-order.md
@@ -1,0 +1,15 @@
+# Epics (priority order)
+
+1. Teams & Rosters — Launch Blocker
+2. Scheduling — Launch Blocker
+3. Availability — Launch Blocker
+4. Messaging & Announcements — Launch Blocker
+5. Notifications & Preferences — V1 Important
+
+6) Multi-Team Support — V1 Important
+7) Self-Hosting Docs & Setup Wizard — V1 Important
+8) RBAC & Org Scoping — Cross-cutting foundation
+9) CI/CD & Quality Gates — Cross-cutting foundation
+10) Observability & Error Handling (minimal) — V1 Nice-to-have
+
+---

--- a/docs/backlog/foundations-cicd-quality-gates.md
+++ b/docs/backlog/foundations-cicd-quality-gates.md
@@ -1,0 +1,6 @@
+# Foundations: CI/CD & Quality Gates
+
+Tasks:
+
+- Ensure lint, typecheck, Vitest, Playwright, axe run in CI.
+- Minimal seed data + test harness docs.

--- a/docs/backlog/foundations-compliance-privacy.md
+++ b/docs/backlog/foundations-compliance-privacy.md
@@ -1,0 +1,8 @@
+# Foundations: Compliance & Privacy
+
+Tasks:
+
+- Implement and test Right‑to‑be‑Forgotten flow (data export + deletion queues).
+- Privacy policy page; document processors (email/push) and DPAs.
+- Account lockout after 5 failed logins (unit/integration tests).
+- Backups: nightly job and weekly restore test automation; runbook docs.

--- a/docs/backlog/foundations-rbac-org-scoping.md
+++ b/docs/backlog/foundations-rbac-org-scoping.md
@@ -1,0 +1,6 @@
+# Foundations: RBAC & Org Scoping
+
+Tasks:
+
+- Deny-by-default policy helpers; orgId on all queries.
+- Seed roles; tests for access boundaries.

--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -1,0 +1,16 @@
+# Prioritized Backlog (MVP)
+
+## Table of Contents
+
+- [Prioritized Backlog (MVP)](#table-of-contents)
+  - [Epics (priority order)](./epics-priority-order.md)
+  - [Epic 1: Teams & Rosters](./epic-1-teams-rosters.md)
+  - [Epic 2: Scheduling](./epic-2-scheduling.md)
+  - [Epic 3: Availability](./epic-3-availability.md)
+  - [Epic 4: Messaging & Announcements](./epic-4-messaging-announcements.md)
+  - [Epic 5: Notifications & Preferences](./epic-5-notifications-preferences.md)
+  - [Epic 6: Multi-Team Support](./epic-6-multi-team-support.md)
+  - [Foundations: RBAC & Org Scoping](./foundations-rbac-org-scoping.md)
+  - [Foundations: Compliance & Privacy](./foundations-compliance-privacy.md)
+  - [Foundations: CI/CD & Quality Gates](./foundations-cicd-quality-gates.md)
+  - [Epic 7: Self-Hosting Docs & Setup Wizard](./epic-7-self-hosting-docs-setup-wizard.md)

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,0 +1,14 @@
+# Roadmap (V1 → MVP)
+
+## Table of Contents
+
+- [Roadmap (V1 → MVP)](#table-of-contents)
+  - [Phase 2 — Core MVP Build (target: 4–6 sprints)](./phase-2-core-mvp-build-target-46-sprints.md)
+    - [Sprint 0 — Foundations & Decisions (now)](./phase-2-core-mvp-build-target-46-sprints.md#sprint-0-foundations-decisions-now)
+    - [Sprint 1 — Teams & Rosters (Launch Blocker)](./phase-2-core-mvp-build-target-46-sprints.md#sprint-1-teams-rosters-launch-blocker)
+    - [Sprint 2 — Scheduling (Launch Blocker)](./phase-2-core-mvp-build-target-46-sprints.md#sprint-2-scheduling-launch-blocker)
+    - [Sprint 3 — Availability (Launch Blocker)](./phase-2-core-mvp-build-target-46-sprints.md#sprint-3-availability-launch-blocker)
+    - [Sprint 4 — Messaging & Announcements (Launch Blocker)](./phase-2-core-mvp-build-target-46-sprints.md#sprint-4-messaging-announcements-launch-blocker)
+    - [Sprint 5 — Notifications & Preferences (Important V1)](./phase-2-core-mvp-build-target-46-sprints.md#sprint-5-notifications-preferences-important-v1)
+  - [Phase 3 — MVP Launch](./phase-3-mvp-launch.md)
+  - [Phase 4 — Stabilization & Community](./phase-4-stabilization-community.md)

--- a/docs/roadmap/phase-2-core-mvp-build-target-46-sprints.md
+++ b/docs/roadmap/phase-2-core-mvp-build-target-46-sprints.md
@@ -1,0 +1,62 @@
+# Phase 2 — Core MVP Build (target: 4–6 sprints)
+
+Exit criteria (from PRD):
+
+- 1 pilot school active on all 4 core workflows
+- 95%+ test pass on launch blockers
+- Docker self-host verified by a non-dev
+- Ad-free and free-forever principle documented and enforced (see license
+  decision)
+
+## Sprint 0 — Foundations & Decisions (now)
+
+- Decide license + policy to uphold “ad‑free, free‑forever” (see
+  `docs/license-options.md`).
+- Confirm org scoping model (single-tenant V1) and RBAC roles.
+- Align Prisma schema to V1 entities (Organization, Team, User, Membership,
+  Event, Availability, Message[Thread], NotificationPreference).
+- Baseline CI: typecheck, lint, unit (Vitest), e2e (Playwright), a11y (axe).
+- Create feature flags or route stubs for MVP epics.
+
+## Sprint 1 — Teams & Rosters (Launch Blocker)
+
+Deliverables:
+
+- Teams: CRUD, membership roles (coach, player, guardian), org scope enforced.
+- Roster: Add/edit/remove players and guardians; CSV import/export.
+- UX: Team list, roster table, role badges.
+- Tests: unit + Playwright happy paths; CSV import edge cases.
+- Routes: `/teams`, `/teams/:teamId`, `/teams/:teamId/roster`.
+
+## Sprint 2 — Scheduling (Launch Blocker)
+
+Deliverables:
+
+- Events: practices/games/meetings CRUD; team filter; conflict hints.
+- Calendar views (list + month/week).
+- iCal/ICS export; timezone handling.
+- Routes: `/teams/:teamId/events`, `/events/:eventId`.
+
+## Sprint 3 — Availability (Launch Blocker)
+
+Deliverables:
+
+- RSVP (Yes/No/Maybe) per user; summaries for coaches.
+- Reminders for unmarked availability (job + email stub).
+- Route: `/events/:eventId/availability`.
+
+## Sprint 4 — Messaging & Announcements (Launch Blocker)
+
+Deliverables:
+
+- Team-wide announcements; coach↔parent direct messages; basic team chat.
+- Thread list + message history; RBAC + audit log on messages.
+- Routes: `/threads`, `/threads/:id/messages`.
+
+## Sprint 5 — Notifications & Preferences (Important V1)
+
+Deliverables:
+
+- Email via Resend (with SMTP fallback); PWA push opt‑in.
+- User notification preferences; retries and DLQ.
+- Admin error log view.

--- a/docs/roadmap/phase-3-mvp-launch.md
+++ b/docs/roadmap/phase-3-mvp-launch.md
@@ -1,0 +1,5 @@
+# Phase 3 — MVP Launch
+
+- Self-hosting docs (Docker) validated by non-developer.
+- Staging → pilot school onboarding; uptime monitors.
+- Governance: CONTRIBUTING, CODE_OF_CONDUCT, maintainers policy.

--- a/docs/roadmap/phase-4-stabilization-community.md
+++ b/docs/roadmap/phase-4-stabilization-community.md
@@ -1,0 +1,8 @@
+# Phase 4 — Stabilization & Community
+
+- Security hardening, backups/runbook validation, plugin hooks scaffold.
+
+Notes:
+
+- Multi-team user dashboard can land across Sprints 2–3 (thin slice first).
+- Keep SQLite; plan V2 Postgres path in architecture (already noted).


### PR DESCRIPTION
This PR:
- Shards PRD & Architecture (via md-tree) into docs/prd and docs/architecture
- Shards backlog and roadmap into sectioned docs
- Adds /healthz and /readyz endpoints in server/index.ts
- Adds Privacy Policy (Draft) and links it in README

Validation:
- Typecheck, lint, unit tests pass locally

Follow-ups:
- Compose + self-hosting docs
- Setup Wizard scaffolding
- Notifications error log route
